### PR TITLE
RELEASE-V1.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- `reselectPlayer(playerList: string[] = players): string` now will no longer change the current player unless it manages to locate an avalible one from the given array.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
 # Changelog
 
 - `reselectPlayer(playerList: string[] = players): string` now will no longer change the current player unless it manages to locate an avalible one from the given array.
+- Added ability to play from URLs.
+- Added specific options to mpv to reduce latency, prevent video output, disable user-configuration, and prevent any attempts to output text.
+- Added specific options to mplayer to prevent video outputs and GUI usage, disable user-configuration, and reduce the number of attempts to output text.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,3 +4,8 @@
 - Added ability to play from URLs.
 - Added specific options to mpv to reduce latency, prevent video output, disable user-configuration, and prevent any attempts to output text.
 - Added specific options to mplayer to prevent video outputs and GUI usage, disable user-configuration, and reduce the number of attempts to output text.
+- Added specific options to ffplay to prevent text output.
+- Added specific options to cvlc to reduce text output and prevent video output.
+- Added sepcific options to play and mpg321/mpg123 to prevent text output.
+
+Note that text isn't going to appear in the console even if these options are disabled; they just don't need to do it in the first place, so I took lengths to disable it.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Player soundser byer shellinger outer toer oneer ofer theer availableer audioer 
 
 A beefed-up version of [play-sound](https://github.com/shime/play-sound "play-sound GitHub repository") ([npm entry](https://www.npmjs.com/package/play-sound "play-sound npm entry"),) complete with guaranteed operation with mp3 files, a guarantee to exit when audio playback is over (looking at you cvlc,) pausing and resuming playback (on POSIX-compliant systems *only*, uses SIGSTOP and SIGCONT, so a no-no on Windows,) restarting playback irregardless of whether it is currently playing or the file stopped earlier, more robust URL support, and, best of all, TypeScript!
 
+For Windows users, you will need to make sure that the command-line players on your system are present somewhere in the PATH variable, or manually specify them using the file location of the executables.
+
 ## Installation
 
 player-sounder can be installed from [npm](https://www.npmjs.com/package/player-sounder "player-sounder npm entry") using the following command(s):

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Player soundser byer shellinger outer toer oneer ofer theer availableer audioer playerser.
 
-A beefed-up version of [play-sound](https://github.com/shime/play-sound "play-sound GitHub repository") ([npm entry](https://www.npmjs.com/package/play-sound "play-sound npm entry"),) complete with guaranteed operation with mp3 files, a guarantee to exit when audio playback is over (looking at you cvlc,) pausing and resuming playback (on POSIX-compliant systems *only*, uses SIGSTOP and SIGCONT, so a no-no on Windows,) restarting playback irregardless of whether it is currently playing or the file stopped earlier, and, best of all, TypeScript!
+A beefed-up version of [play-sound](https://github.com/shime/play-sound "play-sound GitHub repository") ([npm entry](https://www.npmjs.com/package/play-sound "play-sound npm entry"),) complete with guaranteed operation with mp3 files, a guarantee to exit when audio playback is over (looking at you cvlc,) pausing and resuming playback (on POSIX-compliant systems *only*, uses SIGSTOP and SIGCONT, so a no-no on Windows,) restarting playback irregardless of whether it is currently playing or the file stopped earlier, more robust URL support, and, best of all, TypeScript!
 
 ## Installation
 
@@ -50,7 +50,7 @@ A mapping between string keys and a given type. Just objects with a specified va
 
 #### *type AudioProcess*
 
-More relavent type name for returned audio-playing processes.
+More relavent type name for returned audio-playing processes. Alias of ChildProcessWithNullStreams from [child_process.](https://nodejs.org/docs/latest-v19.x/api/child_process.html "child_process node.js API page.")
 
 ### Constants
 
@@ -60,13 +60,23 @@ The default command line audio players. All of them should be mp3 compatible.
 
 Contains: `"mplayer"`, `"mpv"`, `"ffplay"`, `"cvlc"`, `"play"`, `"mpg123"`, and `"mpg321"`.
 
+#### *URLPlayers: string\[\]*
+
+A list of command line audio players that are capable of playing audio sourced from a URL. All of them should be mp3 compatible.
+
+Contains: `"mpv"`, `"mplayer"`.
+
 #### *playerOptions: Dictionary\<string\[\]\>*
 
 Options to supply to each player.
 
 Should atleast have the options necessary to prevent windows or other graphical hoo-has from being displayed and ensure that the player exits when playback is over.
 
-Contains: `ffplay: ["-nodisp", "-autoexit"]`, `cvlc: ["--play-and-exit"]`.
+Contains: 
+- ffplay: [`"-nodisp"`, `"-autoexit"`].
+- cvlc: [`"--play-and-exit"`].
+- mpv: [`"--no-video"`, `"--no-terminal"`, `"--no-config"`, `"--profile=low-latency"`].
+- mplayer: [`"-nogui"`, `"-vc"`, `"null"`, `"-vo"`, `"null"`, `"-noconfig"`, `"all"`, `"-really-quiet"`].
 
 ### Functions
 
@@ -76,7 +86,15 @@ Gets the first available player on the system.
 
 On first call, attempts to select a player from [players.](README.md#players-string "players: string[]")
 
-Throws an error if there are no available players.
+Throws an Error if there are no available players.
+
+#### *getAvalibleURLPlayer(): string*
+
+Gets the first available URL player on the system.
+
+On first call, attempts to select a player from [URLPlayers.](README.md#urlplayers-string "URLPlayers: string[]")
+
+Throws an Error if there are no available players.
 
 #### *reselectPlayer(playerList: string\[\] = players): string*
 
@@ -86,7 +104,17 @@ The list of players defaults to [players](README.md#players-string "players: str
 
 Returns the selected player.
 
-Throws an error if there are no available players.
+Throws an Error if there are no available players.
+
+#### *reselectURLPlayer(URLPlayerList: string\[\] = URLPlayers): string*
+
+Updates the URL player to the first available player within the given list.
+
+The list of URL players defaults to [URLPlayers](README.md#urlplayers-string "URLPlayers: string[]") when one isn't specified.
+
+Returns the selected URL player.
+
+Throws an Error if there are no available players.
 
 #### *overridePlayer(player: string): boolean*
 
@@ -96,13 +124,33 @@ Attempts to forcefully set a different player.
 
 Returns `true` if it found the player. If unable (i.e. `false`,) the original player is kept.
 
-#### *playFile(filePath: string, options: Dictionary<string\[\]> = playerOptions): AudioProcess*
+#### *overrideURLPlayer(URLPlayer: string): boolean*
+
+Attempts to forcefully set a different URL player.
+
+`URLPlayer` is the path to the new player.
+
+Returns `true` if it found the player. If unable (i.e. `false`,) the original player is kept.
+
+#### *playFile(filePath: string, options: Dictionary\<string\[\]\> = playerOptions): AudioProcess*
 
 Launches a child process to play the given audio file.
  
 `options` are the pool of options for each player. The current player's name is used to get the relavent options from the dictionary.
 
-Throws an error if the file could not be opened or there are no available players.
+Throws an Error if the file cannot be accessed or there are no available players.
+
+#### *playURL(url: string, options: Dictionary\<string\[\]\> = playerOptions): AudioProcess*
+
+WARNING: Offers absolutely no URL validation. 
+
+Launches a child process to play the audio file at the given URL.
+
+`options` are the pool of options for each player. The current player's name is used to get the relavent options from the dictionary.
+
+Throws an Error if the file cannot be accessed or there are no available players.
+
+playURL() can have a resonably large latencey from when it's called to when the sound is played, and it makes no attempt to cache queried audio files; if a sound needs to be played exactly at the time of calling, or it's needed repeatedly, download it and use [playFile()](README.md#playfilefilepath-string-options-dictionarystring--playeroptions-audioprocess "playFile(filePath: string, options: Dictionary<string[]> = playerOptions): AudioProcess") instead.
 
 #### *onError(audioProcess: AudioProcess): Promise\<number\>*
 
@@ -176,3 +224,14 @@ overridePlayer("mpv");
 let options = {"mpv": ["--volume=400"]};
 let audioProcess = playFile("FILE NAME GOES HERE", options);
 ```
+
+## Changelog
+
+- `reselectPlayer(playerList: string[] = players): string` now will no longer change the current player unless it manages to locate an avalible one from the given array.
+- Added ability to play from URLs.
+- Added specific options to mpv to reduce latency, prevent video output, disable user-configuration, and prevent any attempts to output text.
+- Added specific options to mplayer to prevent video outputs and GUI usage, disable user-configuration, and reduce the number of attempts to output text.
+
+### 1.0.0
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ playerSounder.onError(audioProcess).then((errorCode) => {
 Plays a file with mpv at 400% volume:
 
 ```TypeScript
-import { overridePlayer, playFile } from "player-sounder";
+import { overridePlayer, playFile, playerOptions } from "player-sounder";
 
 overridePlayer("mpv");
-let options = {"mpv": ["--volume=400"]};
-let audioProcess = playFile("FILE NAME GOES HERE", options);
+let mpvOptions = playerOptions["mpv"].concat("--volume=400");
+let audioProcess = playFile("FILE NAME GOES HERE", {mpv: mpvOptions});
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A mapping between string keys and a given type. Just objects with a specified va
 
 #### *type AudioProcess*
 
-More relavent type name for returned audio-playing processes. Alias of ChildProcessWithNullStreams from [child_process.](https://nodejs.org/docs/latest-v19.x/api/child_process.html "child_process node.js API page.")
+More relavent type name for returned audio-playing processes. Alias of ChildProcessWithoutNullStreams from [child_process.](https://nodejs.org/docs/latest-v19.x/api/child_process.html "child_process node.js API page.")
 
 ### Constants
 
@@ -64,7 +64,9 @@ Contains: `"mplayer"`, `"mpv"`, `"ffplay"`, `"cvlc"`, `"play"`, `"mpg123"`, and 
 
 A list of command line audio players that are capable of playing audio sourced from a URL. All of them should be mp3 compatible.
 
-Contains: `"mpv"`, `"mplayer"`.
+Contains: `"mpv"`, `"mplayer"`, `"ffplay"`, and `"cvlc"`.
+
+NOTE: SoX and mpg123/mpg321 have URL support, but seem a little unreliable, so I'm not including them.
 
 #### *playerOptions: Dictionary\<string\[\]\>*
 
@@ -73,10 +75,13 @@ Options to supply to each player.
 Should atleast have the options necessary to prevent windows or other graphical hoo-has from being displayed and ensure that the player exits when playback is over.
 
 Contains: 
-- ffplay: [`"-nodisp"`, `"-autoexit"`].
-- cvlc: [`"--play-and-exit"`].
+- ffplay: [`"-nodisp"`, `"-vn"`, `"-loglevel"`, `"quiet"`, `"-autoexit"`].
+- cvlc: [`"--play-and-exit"`, `"--no-video"`, `"--verbose"`, `"0"`].
 - mpv: [`"--no-video"`, `"--no-terminal"`, `"--no-config"`, `"--profile=low-latency"`].
 - mplayer: [`"-nogui"`, `"-vc"`, `"null"`, `"-vo"`, `"null"`, `"-noconfig"`, `"all"`, `"-really-quiet"`].
+- play: [`"--no-show-progress"`, `"-V0"`].
+- mpg123: [`"--quiet"`].
+- mpg321: [`"--quiet"`].
 
 ### Functions
 
@@ -231,6 +236,11 @@ let audioProcess = playFile("FILE NAME GOES HERE", options);
 - Added ability to play from URLs.
 - Added specific options to mpv to reduce latency, prevent video output, disable user-configuration, and prevent any attempts to output text.
 - Added specific options to mplayer to prevent video outputs and GUI usage, disable user-configuration, and reduce the number of attempts to output text.
+- Added specific options to ffplay to prevent text output.
+- Added specific options to cvlc to reduce text output and prevent video output.
+- Added sepcific options to play and mpg321/mpg123 to prevent text output.
+
+Note that text isn't going to appear in the console even if these options are disabled; they just don't need to do it in the first place, so I took lengths to disable it.
 
 ### 1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "player-sounder",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Player soundser byer shellinger outer toer oneer ofer theer availableer audioer playerser",
   "author": "ona li toki e jan Epiphany tawa mi (https://github.com/ona-li-toki-e-jan-Epiphany-tawa-mi)",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import findExec = require("find-exec");
-import { ChildProcess, ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import * as fs from "fs";
 const R_OK = fs.constants.R_OK;
 
@@ -54,11 +54,12 @@ export function getAvaliblePlayer(): string {
  * @throws If there are no available players.
  */
 export function reselectPlayer(playerList: string[] = players): string {
-    _player = findExec(playerList);
+    let newPlayer = findExec(playerList);
 
-	if (!_player)
+	if (!newPlayer)
         throw `Unable to find any sound players on the system! (attempted to look for ${players})`;
 
+    _player = newPlayer;
     return _player;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,27 +21,36 @@ export type AudioProcess = ChildProcessWithoutNullStreams;
  * Command line audio players. Must be mp3 compatible.
  */
 export const players: string[] = [ "mplayer", "mpv", "ffplay"
-                                 , "cvlc" /* from VLC */, "play" /* from SoX(?) */
+                                 , "cvlc" /* VLC */, "play" /* SoX */
 			                     , "mpg123", "mpg321" /* Same player, different name */];
 
 /**
  * A list of command line audio players that are capable of playing audio sourced from a url.
+ * @attention SoX and mpg123/mpg321 have URL support, but seem a little unreliable, so I'm not including them.
  */                            
-export const URLPlayers: string[] = ["mpv", "mplayer"]; //TODO Add more.
+export const URLPlayers: string[] = [ "mpv", "mplayer", "ffplay"
+                                    , "cvlc" /* VLC */]; 
 
 /**
  * Various options to supply to each player.
  * Namely makes sure players don't open any windows and exit when done.
  */
-export const playerOptions: Dictionary<string[]> = { ffplay:  ["-nodisp", "-autoexit"]
-	                  			          		   , cvlc:    ["--play-and-exit"]
+export const playerOptions: Dictionary<string[]> = { ffplay:  [ "-nodisp", "-vn" /* Prevents video output and other visual hoo-has. */
+                                                              , "-loglevel", "quiet"
+                                                              , "-autoexit"]
+	                  			          		   , cvlc:    [ "--play-and-exit"
+                                                              , "--no-video"
+                                                              , "--verbose", "0" /* Reduces unneeded text output. */]
                                                    , mpv:     [ "--no-video"
                                                               , "--no-terminal"         /* Prevents unneeded terminal output. */
                                                               , "--no-config"           /* Prevents any possible conflict with user configuration. */
                                                               , "--profile=low-latency" /* Low-latency specifier to try and play audio ASAP. */]
                                                    , mplayer: [ "-nogui", "-vc", "null", "-vo", "null" /* Prevents video output and other visual hoo-has. */
                                                               , "-noconfig", "all"                     /* Prevents any possible conflict with user configuration. */                                                    
-                                                              , "-really-quiet"]};
+                                                              , "-really-quiet"]
+                                                   , play:    [ "--no-show-progress", "-V0" /* Prevents unneeded terminal output. */]
+                                                   , mpg123:  [ "--quiet"]
+                                                   , mpg321:  [ "--quiet"]};
 
 let _player: string | null = null;
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,11 +25,23 @@ export const players: string[] = [ "mplayer", "mpv", "ffplay"
 			                     , "mpg123", "mpg321" /* Same player, different name */];
 
 /**
+ * A list of command line audio players that are capable of playing audio sourced from a url.
+ */                            
+export const URLPlayers: string[] = ["mpv", "mplayer"]; //TODO Add more.
+
+/**
  * Various options to supply to each player.
  * Namely makes sure players don't open any windows and exit when done.
  */
-export const playerOptions: Dictionary<string[]> = { ffplay: ["-nodisp", "-autoexit"]
-	                  			          		   , cvlc:   ["--play-and-exit"]};
+export const playerOptions: Dictionary<string[]> = { ffplay:  ["-nodisp", "-autoexit"]
+	                  			          		   , cvlc:    ["--play-and-exit"]
+                                                   , mpv:     [ "--no-video"
+                                                              , "--no-terminal"         /* Prevents unneeded terminal output. */
+                                                              , "--no-config"           /* Prevents any possible conflict with user configuration. */
+                                                              , "--profile=low-latency" /* Low-latency specifier to try and play audio ASAP. */]
+                                                   , mplayer: [ "-nogui", "-vc", "null", "-vo", "null" /* Prevents video output and other visual hoo-has. */
+                                                              , "-noconfig", "all"                     /* Prevents any possible conflict with user configuration. */                                                    
+                                                              , "-really-quiet"]};
 
 let _player: string | null = null;
 /**
@@ -37,7 +49,7 @@ let _player: string | null = null;
  * On first call, attempts to select a player from {@link players}.
  *
  * @returns The player.
- * @throws If there are no available players.
+ * @throws [Error] If there are no available players.
  */
 export function getAvaliblePlayer(): string {
 	if (!_player)
@@ -46,21 +58,53 @@ export function getAvaliblePlayer(): string {
 	return _player;
 }
 
+let _URLPlayer: string | null = null;
+/**
+ * Gets the first available URL player on the system.
+ * On first call, attempts to select a URL player from {@link URLPlayers}.
+ *
+ * @returns The URL player.
+ * @throws [Error] If there are no available URL players.
+ */
+export function getAvalibleURLPlayer(): string {
+    if (!_URLPlayer)
+        reselectURLPlayer();
+
+	return _URLPlayer;
+}
+
 /**
  * Updates the player to the first available player within the given list.
  *
  * @param playerList The list of players to select from, defaults to {@link players}.
  * @returns The player.
- * @throws If there are no available players.
+ * @throws [Error] If there are no available players.
  */
 export function reselectPlayer(playerList: string[] = players): string {
     let newPlayer = findExec(playerList);
 
 	if (!newPlayer)
-        throw `Unable to find any sound players on the system! (attempted to look for ${players})`;
+        throw new Error(`Unable to find any sound players on the system! (attempted to look for ${playerList})`);
 
     _player = newPlayer;
     return _player;
+}
+
+/**
+ * Updates the URL player to the first available player within the given list.
+ *
+ * @param URLPlayerList The list of players to select from, defaults to {@link URLPlayers}.
+ * @returns The URL player.
+ * @throws [Error] If there are no available URL players.
+ */
+export function reselectURLPlayer(URLPlayerList: string[] = URLPlayers): string {
+    let newPlayer = findExec(URLPlayerList);
+
+	if (!newPlayer)
+        throw new Error(`Unable to find any URL players on the system! (attempted to look for ${URLPlayerList})`);
+
+    _URLPlayer = newPlayer;
+    return _URLPlayer;
 }
 
 /**
@@ -72,12 +116,27 @@ export function reselectPlayer(playerList: string[] = players): string {
 export function overridePlayer(player: string): boolean {
     let possiblePlayer = findExec(player);
 
-    if (possiblePlayer) {
-        _player = possiblePlayer
-        return true;
-    }
+    if (!possiblePlayer) 
+        return false;
 
-    return false;
+    _player = possiblePlayer
+    return true;
+}
+
+/**
+ * Attempts to forcefully set a different URL player.
+ * 
+ * @param URLPlayer The path to the new URL player.
+ * @returns Whether the new URL player was found. If false, the original player is kept.
+ */
+export function overrideURLPlayer(URLPlayer: string): boolean {
+    let possiblePlayer = findExec(URLPlayer);
+
+    if (!possiblePlayer) 
+        return false;
+
+    _URLPlayer = possiblePlayer
+    return true;
 }
 
 
@@ -87,19 +146,33 @@ export function overridePlayer(player: string): boolean {
  * 
  * @param filePath audio file path.
  * @param options Various options to supply to each player, defaults to {@link playerOptions}.
- * @throws If the file could not be opened.
- *         If there are no available players.
+ * @throws [Error] If the file could not be opened.
+ *         [Error] If there are no available players.
  */
 export function playFile(filePath: string, options: Dictionary<string[]> = playerOptions): AudioProcess {
 	try {
 		fs.accessSync(filePath, R_OK);
 	} catch (error) {
-		throw `An error occured while trying to open sound file "${filePath}"; unable to open!". Description: ${error}`;
+		throw new Error(`An error occured while trying to open sound file "${filePath}"; unable to open!". Description: ${error}`);
 	}
 
 	const player = getAvaliblePlayer();
 	const args   = (options[player] || []).concat(filePath);
 	
+    return spawn(player, args);
+}
+
+/**
+ * Launches a child process to play the audio file at the given URL.
+ * 
+ * @param url audio file URL.
+ * @param options Various options to supply to each player, defaults to {@link playerOptions}.
+ * @throws [Error] If there are no available players.
+ */
+export function playURL(url: string, options: Dictionary<string[]> = playerOptions): AudioProcess {
+    const player = getAvalibleURLPlayer();
+    const args   = (options[player] || []).concat(url);
+
     return spawn(player, args);
 }
 


### PR DESCRIPTION
## Changelog

- `reselectPlayer(playerList: string[] = players): string` now will no longer change the current player unless it manages to locate an avalible one from the given array.
- Added ability to play from URLs.
- Added specific options to mpv to reduce latency, prevent video output, disable user-configuration, and prevent any attempts to output text.
- Added specific options to mplayer to prevent video outputs and GUI usage, disable user-configuration, and reduce the number of attempts to output text.
- Added specific options to ffplay to prevent text output.
- Added specific options to cvlc to reduce text output and prevent video output.
- Added sepcific options to play and mpg321/mpg123 to prevent text output.

Note that text isn't going to appear in the console even if these options are disabled; they just don't need to do it in the first place, so I took lengths to disable it.